### PR TITLE
chore: AttachStorage method

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -133,7 +133,7 @@ func AttachDisk(vm *vbg.VirtualMachine) error {
     vb := vbg.NewVBox(vbg.Config{})
     ctx := context.Background()  
     context.WithTimeout(ctx, 1*time.Minute)
-    vb.AttachStorage(vm, disk2)
+    vb.AttachStorageDrive(vm, disk2)
 }
 ```
 


### PR DESCRIPTION
- Rework AttachStorage method to handle args only and switch func to private
- Add AttachStorageDrive to given correct arguments to attachStorage method
- Add AttachOpticalDrive to given correct arguments to attachStorage method

Problem with old method, was an optical drive cannot be attach with flags "non-rotational"
```
VBoxManage: error: Setting the non-rotational medium flag rejected as the device attached to device slot 0 on port 29 of controller 'Controller' is not a hard disk
```